### PR TITLE
Document non-root testing requirement

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Ensure non-root
+        run: |
+          if [ "$(id -u)" = 0 ]; then
+            echo "Do not run tests as root"
+            exit 1
+          fi
       - run: make fmt
       - run: make vet
       - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Run Python unit tests:
 pytest
 ```
 
+> **Note**: Some Go tests use an embedded Postgres instance that cannot run as
+> the root user. Run the test suite under a regular account.
+
 Run frontend tests with Vitest:
 
 ```bash


### PR DESCRIPTION
## Summary
- note that Go tests require running as non-root
- fail CI if jobs run as root

## Testing
- `pytest -q`
- `npx vitest run` *(fails to run without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863d0086820832db8da29be1c654f61